### PR TITLE
docs: adopt Vector-First storage hierarchy

### DIFF
--- a/docs/embedding-context.md
+++ b/docs/embedding-context.md
@@ -17,10 +17,12 @@ Output: arrow_array::FixedSizeListArray
 
 Cache strategy:
   Phase 1: HashMap<[u8;32], Vec<f32>>  in-memory
-  Phase 2: persisted to DuckDB embedding_cache table
+  Phase 1+: embedding_cache.lance      Arrow-native, same engine as facts.lance
   Key: blake3(text) → [u8; 32]
   Invalidation: cache entries are keyed by model_id; changing models auto-invalidates
 ```
+
+`embedding_cache.lance` replaces the DuckDB-based `embedding_cache` table from earlier designs. Keeping the cache in Lance (same engine as `facts.lance`) eliminates the cross-store desync scenario — cache writes and fact writes fail or succeed within the same storage layer.
 
 Fallback: `NoopEmbeddingEngine` returns zero vectors — enables CI and tests without model files.
 
@@ -33,14 +35,20 @@ Given query `q` and token budget `budget`:
 ```
 1. WorkingMemory scan            → most recent N turns (always included; anchors recency)
 2. FactStore ANN search          → embed(q) → LanceDB ANN on facts.lance
-3. LifecycleStore filter         → DuckDB removes expired / consolidated ids
-4. RelationshipStore traversal   → LanceGraph neighbors of entities found in step 2 (Phase 2)
+                                   filter: ttl_expires_ms IS NULL OR ttl_expires_ms > now_ms()
+3. RelationshipStore traversal   → LanceGraph neighbors of entities found in step 2 (Phase 2+)
+4. [Phase 3 only] DuckDB filter  → exclude ids under active consolidation
 5. Merge results as RecordBatch
 6. Score: Relevance × Recency × Diversity
 7. Deduplicate by blake3(content)
 8. Trim to fit within token_budget
 9. Format as AssembledContext.prompt_prefix
 ```
+
+Key changes from earlier design:
+- **TTL filtering** (step 2) is now a Lance column predicate, not a DuckDB lifecycle query. No secondary store required in Phases 1 and 2.
+- **LanceGraph traversal** (step 3) moves to immediately after ANN — it is the Phase 2 enhancement, not DuckDB.
+- **DuckDB** (step 4) is Phase 3 only, used for consolidation-job-aware filtering, not basic lifecycle management.
 
 All intermediate results are Arrow RecordBatches — no intermediate serialization.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,12 +1,25 @@
 # Roadmap
 
+## Architecture Basis
+
+membrane uses a **Vector-First storage hierarchy** (see `storage-architecture.md`):
+
+- **Phase 1** — Tier 1 only: LanceDB core (vector store, TTL, embedding cache)
+- **Phase 2** — Tier 2: LanceGraph (entity graph, relationship traversal)
+- **Phase 3** — Tier 3: DuckDB (SQL federation, Iceberg, cross-session analytics)
+
+DuckDB is an **optional analytics layer** introduced only in Phase 3. It does not participate in the `store_episode()` write path in any phase.
+
+---
+
 ## Current State
 
 Design complete. No production code exists yet. Deliverables so far:
 
 - [x] Ecosystem survey — confirmed no equivalent Rust library exists
 - [x] Architecture decision: Arrow as IO common language
-- [x] Storage schema: `facts.lance`, `memory_graph/`, DuckDB lifecycle tables
+- [x] Vector-First hierarchy adopted: LanceDB primary → LanceGraph additive → DuckDB analytics
+- [x] Storage schema: `facts.lance` (with `ttl_expires_ms`), `embedding_cache.lance`, `memory_graph/`
 - [x] Core trait design: `FactStore`, `RelationshipStore`, `LifecycleStore`, `EmbeddingEngine`
 - [x] Crate layout defined (`src/arrow/` as schema source of truth)
 - [x] Automation guidelines (A/B/C/D levels)
@@ -14,9 +27,9 @@ Design complete. No production code exists yet. Deliverables so far:
 
 ---
 
-## Phase 1 — Fact Memory MVP
+## Phase 1 — Fact Memory MVP (Tier 1: LanceDB)
 
-**Goal:** store and retrieve episodes; assemble context within a token budget. No DuckDB or LanceGraph required.
+**Goal:** store and retrieve episodes with TTL; assemble context within a token budget. No DuckDB or LanceGraph required.
 
 ### Milestones
 
@@ -24,18 +37,26 @@ Design complete. No production code exists yet. Deliverables so far:
 |-----------|-------------|------|
 | 1.1 | `src/error.rs` — `MembraneError` with `thiserror` | [ ] |
 | 1.2 | `src/types.rs` — `MemoryId`, `Episode`, `Role`, `RetrievedMemory`, `AssembledContext` | [ ] |
-| 1.3 | `src/arrow/mod.rs` — Arrow schema for `facts.lance`; `src/arrow/convert.rs` — `Episode → RecordBatch` | [ ] |
+| 1.3 | `src/arrow/mod.rs` — Arrow schema for `facts.lance` (including `ttl_expires_ms` column); `src/arrow/convert.rs` — `Episode → RecordBatch` | [ ] |
+| 1.3a | `src/arrow/mod.rs` — Arrow schema for `embedding_cache.lance` (key, model_id, vector) | [ ] |
 | 1.4 | `src/memory/working.rs` — `WorkingMemory` ring buffer (no deps) | [ ] |
 | 1.5 | `src/storage/mod.rs` — `FactStore`, `EmbeddingEngine` traits (RPITIT) | [ ] |
 | 1.6 | `src/storage/lance.rs` — `LanceFactStore` (feature = `store-lance`) | [ ] |
-| 1.7 | `src/embedding/mod.rs` — `NoopEmbeddingEngine`; `src/embedding/cache.rs` — in-memory HashMap cache | [ ] |
+| 1.7 | `src/embedding/mod.rs` — `NoopEmbeddingEngine`; `src/embedding/cache.rs` — in-memory HashMap cache (Phase 1), `embedding_cache.lance` (Phase 1 opt-in) | [ ] |
 | 1.8 | `src/embedding/mistral.rs` — `MistralEmbeddingEngine` (feature = `embedding-local`) | [ ] |
-| 1.9 | `src/ops/store.rs` — `store_episode()`: embed → RecordBatch → LanceDB | [ ] |
-| 1.10 | `src/ops/retrieve.rs` — `retrieve()`: ANN search on `facts.lance` only | [ ] |
-| 1.11 | `src/context/token_budget.rs` — character heuristic; `src/context/assembler.rs` — `assemble_context()` | [ ] |
-| 1.12 | `src/lib.rs` — `MembraneEngine::open()`, `store_episode()`, `assemble_context()` public API | [ ] |
-| 1.13 | `examples/basic_store_retrieve.rs`, `examples/context_assembly.rs` | [ ] |
-| 1.14 | Unit tests: `InMemoryFactStore` (no LanceDB); integration tests: `tempfile::TempDir` + LanceDB | [ ] |
+| 1.9 | `src/ops/store.rs` — `store_episode()`: embed → RecordBatch → LanceDB (single write, idempotent) | [ ] |
+| 1.10 | `src/ops/retrieve.rs` — `retrieve()`: ANN search on `facts.lance` with `ttl_expires_ms` filter | [ ] |
+| 1.11 | `src/ops/forget.rs` — `forget()`: Lance metadata filter sweep + versioned batch delete | [ ] |
+| 1.12 | `src/context/token_budget.rs` — character heuristic; `src/context/assembler.rs` — `assemble_context()` | [ ] |
+| 1.13 | `src/lib.rs` — `MembraneEngine::open()`, `store_episode()`, `assemble_context()`, `forget()` public API | [ ] |
+| 1.14 | `examples/basic_store_retrieve.rs`, `examples/context_assembly.rs` | [ ] |
+| 1.15 | Unit tests: `InMemoryFactStore` (no LanceDB); integration tests: `tempfile::TempDir` + LanceDB | [ ] |
+
+### Key design constraints (Phase 1)
+
+- `store_episode()` is a **single write to one Lance dataset** — no secondary store, no two-phase commit
+- TTL is enforced via `ttl_expires_ms` column predicate; `forget()` is a Lance versioned delete
+- All write operations must be **idempotent** (upsert semantics) — re-execution is always safe (M2 from #22)
 
 ### Acceptance criteria
 
@@ -44,55 +65,69 @@ cargo test                           # all unit tests pass, no external deps
 cargo test --features store-lance    # LanceDB integration tests pass
 cargo run --example basic_store_retrieve --features "store-lance"
 # assemble_context() never exceeds token_budget
-# retrieve() returns most recent + most relevant episodes
+# retrieve() excludes episodes where ttl_expires_ms < now
+# forget() removes target episodes; re-run is a no-op
 ```
 
 ---
 
-## Phase 2 — Lifecycle and Relationships
+## Phase 2 — Entity Graph (Tier 2: LanceGraph)
 
-**Goal:** add DuckDB lifecycle management, LanceGraph entity graph, TTL-based forgetting, and accurate token counting.
+**Goal:** add entity extraction, entity graph storage, and graph-expansion during retrieval. DuckDB still not required.
 
 ### Milestones
 
 | Milestone | Deliverable | Done |
 |-----------|-------------|------|
-| 2.1 | `src/storage/duck.rs` — `DuckLifecycleStore`: DDL for `fact_lifecycle`, `embedding_cache`, `action_patterns`, `consolidation_jobs` | [ ] |
-| 2.2 | `src/storage/graph.rs` — `LanceRelationshipStore`: `entities.lance` + edge datasets | [ ] |
-| 2.3 | `src/arrow/` — extend schemas for entity and edge tables | [ ] |
-| 2.4 | `src/ops/store.rs` — extend `store_episode()` to register lifecycle row in DuckDB | [ ] |
-| 2.5 | `src/ops/retrieve.rs` — extend `retrieve()` with DuckDB lifecycle filter + LanceGraph neighbor expand | [ ] |
-| 2.6 | `src/ops/forget.rs` — `forget()`: DuckDB TTL sweep → batch delete from LanceDB | [ ] |
-| 2.7 | `src/embedding/cache.rs` — persist cache to DuckDB `embedding_cache` table | [ ] |
-| 2.8 | `src/entity/rule_based.rs` — regex NER; `src/entity/resolution.rs` — entity dedup | [ ] |
-| 2.9 | `src/context/token_budget.rs` — Gemma 4 `tokenizer.json` via `tokenizers` crate | [ ] |
-| 2.10 | DuckDB federation: `read_parquet('./data/memory/facts.lance/**/*.parquet')` integration test | [ ] |
+| 2.1 | `src/storage/graph.rs` — `LanceRelationshipStore`: `entities.lance` + edge datasets | [ ] |
+| 2.2 | `src/arrow/` — extend schemas for entity and edge tables | [ ] |
+| 2.3 | `src/ops/store.rs` — extend `store_episode()` to extract entities and write to LanceGraph (entity-first ordering) | [ ] |
+| 2.4 | `src/ops/retrieve.rs` — extend `retrieve()` with LanceGraph neighbor expansion | [ ] |
+| 2.5 | `src/entity/rule_based.rs` — regex NER; `src/entity/resolution.rs` — entity dedup with tombstone soft-delete | [ ] |
+| 2.6 | `src/context/token_budget.rs` — Gemma 4 `tokenizer.json` via `tokenizers` crate | [ ] |
+
+### Key design constraints (Phase 2)
+
+- **Entity-first write ordering** (M4 from #22): always write `entities.lance` before any edge dataset. A crash after entity write but before edge write leaves an orphan node — benign; the entity is still findable via ANN. A dangling edge (edge without entity) cannot occur under this ordering.
+- **Tombstone soft-delete** for entity merges: mark entity as tombstoned → redirect edges → hard-delete. No dangling edge window.
+- LanceGraph and LanceDB share no write path — they are independent Lance datasets. Cross-store consistency is not required.
 
 ### Acceptance criteria
 
 ```bash
-cargo test --features "store-lance store-duck"
-# TTL expiry: episodes with ttl_secs set are deleted after expiry
-# Lifecycle filter: expired ids are excluded from retrieve() results
+cargo test --features "store-lance"
 # Entity graph: neighbors() traversal returns related entities
+# Entity-first: no dangling edges in integration tests
 # Token counting: AssembledContext.tokens_used matches Gemma 4 tokenizer
+# retrieve() graph-expansion returns additional context beyond ANN alone
 ```
 
 ---
 
-## Phase 3 — Automation and Integration
+## Phase 3 — Analytics and Federation (Tier 3: DuckDB)
 
-**Goal:** background consolidation, summarization, tamper-evident audit trail, Python bindings.
+**Goal:** introduce DuckDB as an optional analytics layer for cross-session aggregation, Iceberg federation, and large-scale consolidation. Background automation and Python bindings.
 
 ### Milestones
 
 | Milestone | Deliverable | Done |
 |-----------|-------------|------|
-| 3.1 | `src/ops/consolidate.rs` — `consolidate()` tokio background task; DuckDB drives job scheduling via `consolidation_jobs` | [ ] |
-| 3.2 | `src/ops/summarize.rs` — `summarize()`: compress old episodes into extracted facts via mistral.rs | [ ] |
-| 3.3 | `src/audit/ledger.rs` — `AuditBridge<L: AuditLedger>`: emit blake3-signed `AuditRecord` on every `store_episode()` | [ ] |
-| 3.4 | PyO3 bindings: `MembraneSession` Python class (`store_episode`, `assemble_context`, `forget`) | [ ] |
-| 3.5 | arktrace integration test: chat route stores episodes via membrane; `assemble_context()` feeds Gemma 4 | [ ] |
+| 3.1 | `src/storage/duck.rs` — `DuckLifecycleStore`: DDL for `consolidation_jobs`, `session_index`; reads Lance files via `read_parquet()` | [ ] |
+| 3.2 | `src/ops/consolidate.rs` — `consolidate()` tokio background task; DuckDB drives job scheduling via `consolidation_jobs` state machine (`PENDING → WRITING_SUMMARY → SUMMARY_WRITTEN → DELETING_ORIGINALS → COMPLETE`) | [ ] |
+| 3.3 | `src/ops/summarize.rs` — `summarize()`: compress old episodes into extracted facts via mistral.rs | [ ] |
+| 3.4 | DuckDB federation: `read_parquet('./data/memory/facts.lance/**/*.parquet')` integration test | [ ] |
+| 3.5 | `src/audit/ledger.rs` — `AuditBridge<L: AuditLedger>`: emit blake3-signed `AuditRecord` on every `store_episode()` | [ ] |
+| 3.6 | PyO3 bindings: `MembraneSession` Python class (`store_episode`, `assemble_context`, `forget`) | [ ] |
+| 3.7 | arktrace integration test: chat route stores episodes via membrane; `assemble_context()` feeds Gemma 4 | [ ] |
+
+### DuckDB scope in Phase 3
+
+DuckDB is a **query layer over Lance data**, not a lifecycle manager:
+- It reads `facts.lance` and `entities.lance` as Parquet for aggregation — it does not write to them
+- The only DuckDB-owned tables are `consolidation_jobs` and `session_index`
+- `store_episode()` remains a single Lance write — DuckDB is never in the write path
+
+Write-intent WAL (M1 from #22) applies only to consolidation jobs, not to normal episode writes.
 
 ### Acceptance criteria
 
@@ -102,13 +137,12 @@ cargo run --example context_assembly --features "store-lance store-duck embeddin
 # consolidate(): duplicate episodes merged; summary fact written to facts.lance
 # AuditBridge: every store_episode() emits a signed AuditRecord
 # Python: import membrane; session.store_episode(...); session.assemble_context(...)
+# DuckDB federation: SQL aggregation over multi-session facts.lance works
 ```
 
 ---
 
 ## Future Considerations (post-Phase 3)
-
-These are not planned but are compatible with the current architecture:
 
 | Item | Notes |
 |------|-------|

--- a/docs/storage-architecture.md
+++ b/docs/storage-architecture.md
@@ -1,5 +1,31 @@
 # Storage Architecture
 
+## Vector-First Storage Hierarchy
+
+LLM memory is fundamentally multi-dimensional vectors — semantic retrieval via nearest-neighbor search is the primary operation in every use case. The storage stack reflects this:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Tier 1 — PRIMARY (always active)                       │
+│  LanceDB  facts.lance + embedding_cache.lance           │
+│  Vector ANN · TTL filter · embedding cache              │
+├─────────────────────────────────────────────────────────┤
+│  Tier 2 — ADDITIVE (when entity relationships matter)   │
+│  LanceGraph  entities.lance + edge datasets             │
+│  Multi-hop traversal · knowledge graph                  │
+├─────────────────────────────────────────────────────────┤
+│  Tier 3 — ANALYTICS (when SQL federation needed)        │
+│  DuckDB                                                 │
+│  Cross-session aggregation · Iceberg · BI integration   │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Design rule:** each tier is independently deployable. A system with only Tier 1 is fully functional. Tier 2 and Tier 3 are opt-in extensions that add capability without changing the Tier 1 API.
+
+This hierarchy maps cleanly onto the implementation phases: Phase 1 = Tier 1, Phase 2 = Tier 2, Phase 3 = Tier 3.
+
+---
+
 ## Arrow as IO Common Language
 
 Apache Arrow is the lingua franca that connects all backends with zero-copy data transfer:
@@ -8,38 +34,100 @@ Apache Arrow is the lingua franca that connects all backends with zero-copy data
                     ┌─────────────────────────────────────────────┐
                     │             Apache Arrow boundary            │
                     │                                             │
-  Mistral.rs  ──── RecordBatch ────►  LanceDB (FactMemory)       │
-  embedding                          Lance columnar format        │
-  pipeline                           (Arrow-native on disk)       │
+  Mistral.rs  ──── RecordBatch ────►  LanceDB (Tier 1)           │
+  embedding                          facts.lance                  │
+  pipeline                           embedding_cache.lance        │
+                                     (Arrow-native on disk)       │
                                               │                   │
                     RecordBatch (Arrow IPC)   │                   │
                     ◄─────────────────────────┘                   │
                     │                                             │
                     ▼                                             │
-             LanceGraph (RelationshipMemory)                      │
-             Lance datasets = Arrow tables                        │
+             LanceGraph (Tier 2)                                  │
+             entities.lance + edge datasets                       │
                     │                                             │
-                    │  Arrow C Data Interface / read_parquet()    │
+                    │  read_parquet() — Phase 3 only              │
                     ▼                                             │
-             DuckDB (LifecycleBrain)                              │
-             queries Lance files directly as Parquet              │
-             federates across Iceberg catalogs                    │
+             DuckDB (Tier 3)                                      │
+             SQL federation · Iceberg · cross-session analytics   │
                     └─────────────────────────────────────────────┘
 ```
 
 Every API boundary in membrane passes `arrow_array::RecordBatch`, not serialized bytes. This means:
 - No copy/deserialize overhead between LanceDB → DuckDB
 - Embedding output from mistral.rs is `FixedSizeListArray` — directly inserted into Lance tables
-- DuckDB reads LanceDB's `.lance` files as Parquet without a separate export step
+- DuckDB reads LanceDB's `.lance` files as Parquet without a separate export step (Phase 3)
+
+---
 
 ## Backend Roles
 
-| Backend | Role | Why |
-|---------|------|-----|
-| **LanceDB** | **Fact memory** — stores episodes and extracted facts with their vector embeddings | Lance format is Arrow/Parquet columnar; ANN search + payload filter in one query; same API for local FS and object storage |
-| **LanceGraph** | **Relationship memory** — entity graph stored as Arrow/Lance datasets | Graph edges as Lance tables; same lakehouse model as LanceDB; traversal via Arrow joins |
-| **DuckDB** | **Lifecycle brain** — orchestrates TTL, consolidation state, embedding cache, session index; federates across lakehouses | Speaks Arrow natively; can `read_parquet()` Lance files directly; Iceberg catalog support for cross-store queries |
-| **In-process** | **Working memory** — current session ring buffer | Zero latency; lives entirely in the context window; no Arrow overhead needed |
+| Tier | Backend | Role | Phase |
+|------|---------|------|-------|
+| **1** | **LanceDB** | **Primary** — facts, episodes, embeddings, TTL, embedding cache | Phase 1+ |
+| **2** | **LanceGraph** | **Additive** — entity graph, multi-hop traversal, knowledge graph | Phase 2+ |
+| **3** | **DuckDB** | **Analytics** — SQL federation, Iceberg, cross-session consolidation | Phase 3 only |
+| — | **In-process** | **Working memory** — current session ring buffer | Phase 1+ |
+
+### Tier 1: LanceDB (Primary)
+
+LanceDB serves as the single source of truth for all memory state through Phase 2:
+
+- `facts.lance` — episodes and extracted facts with vector embeddings
+- `embedding_cache.lance` — blake3(text) → vector cache; Arrow-native, no DuckDB dependency
+
+**TTL enforcement** is Lance-native: `ttl_expires_ms` is a reserved column in `facts.lance`. Expiry is applied as a metadata filter (`where ttl_expires_ms IS NULL OR ttl_expires_ms > now_ms()`) at query time and cleaned up in batch via Lance's versioned delete. No secondary lifecycle store required.
+
+This keeps write atomicity simple: `store_episode()` is a single write to one Lance dataset.
+
+### Tier 2: LanceGraph (Additive)
+
+LanceGraph is a logical graph built on top of Lance datasets — no sync with LanceDB required. It adds value when the retrieval question is relational ("what entities are connected to X?") rather than semantic ("what is similar to X?").
+
+Write ordering rule: always write entity node before any edge referencing it (entity-first). This eliminates dangling edge windows without requiring cross-table transactions.
+
+### Tier 3: DuckDB (Optional Analytics Layer)
+
+DuckDB is **not active until Phase 3**. It is introduced only when use cases genuinely require SQL:
+
+- Cross-session aggregation (GROUP BY, window functions over lifecycle data)
+- Iceberg catalog federation (`iceberg_scan()`)
+- BI tool integration
+- Large-scale consolidation job scheduling across many sessions
+
+DuckDB reads Lance files as Parquet — it is a query layer over Tier 1/2 data, not a lifecycle manager. It never participates in the `store_episode()` write path.
+
+---
+
+## facts.lance Schema (Reserved Columns)
+
+```
+id               FixedSizeBinary(16)   blake3(content + timestamp_ms)[:16]
+session_id       Utf8
+timestamp_ms     UInt64
+role             Utf8                  "user" | "assistant" | "system"
+content          Utf8
+embedding        FixedSizeList<f32>    model-dimension (e.g. 768 for nomic-embed-text)
+fact_kind        Utf8                  "episode" | "fact" | "summary"
+ttl_expires_ms   UInt64 (nullable)     null = never expires
+source_ids       List<FixedSizeBinary(16)>   for facts derived from episodes
+```
+
+`ttl_expires_ms` is the sole mechanism for lifecycle management in Tier 1. No external store required.
+
+---
+
+## embedding_cache.lance Schema
+
+```
+key        FixedSizeBinary(32)    blake3(text)
+model_id   Utf8                   invalidated on model change
+vector     FixedSizeList<f32>     cached embedding
+```
+
+Replaces the Phase 2 DuckDB `embedding_cache` table from the original design. Cache hits avoid re-embedding on edge hardware where inference is expensive.
+
+---
 
 ## Lakehouse Deployment Model
 
@@ -48,16 +136,17 @@ LanceDB and LanceGraph use the same Lance storage format regardless of where dat
 ```
 Local (edge):                          Object storage (cloud):
   ./data/memory/facts.lance     ←→       s3://bucket/memory/facts.lance
-  ./data/memory/graph/               s3://bucket/memory/graph/
-  ./data/memory/relations.lance       gcs://bucket/memory/relations.lance
+  ./data/memory/embedding_cache.lance    s3://bucket/memory/embedding_cache.lance
+  ./data/memory/graph/                   s3://bucket/memory/graph/
 
 Same Rust API. Same schema. Deployment is configuration, not code.
 ```
 
-DuckDB federates across these locations via:
+DuckDB (Phase 3) federates across these locations via:
 - `read_parquet('s3://...')` / `read_parquet('./data/...')` — Lance files are valid Parquet
 - Iceberg catalog queries for versioned, ACID-compliant lakehouse access
-- Arrow Flight for in-process zero-copy exchange with LanceDB
+
+---
 
 ## Edge ↔ Cloud Sync — Intentionally Out of Scope
 
@@ -67,4 +156,21 @@ membrane's role is to provide knowledge that assists judgment: similar past case
 
 Learning and improvement — aggregating episodes and extracted facts into object storage for offline analysis or model fine-tuning — is post-processing work that happens outside the judgment loop. That belongs in a separate layer, not in a memory management library.
 
-Possible sync strategies (shared object storage, log-based replication, Iceberg table versioning) are application-level decisions. membrane imposes no constraint and is compatible with any of them via the lakehouse model: the same Lance/Parquet files readable locally are readable from object storage without code changes.
+Possible sync strategies (shared object storage, log-based replication, Iceberg table versioning) are application-level decisions. membrane imposes no constraint and is compatible with any of them via the lakehouse model.
+
+---
+
+## Relationship to Issue #22 (Data Consistency)
+
+Adopting the Vector-First hierarchy eliminates the majority of cross-store inconsistency scenarios identified in #22:
+
+| Original scenario | Status under Vector-First |
+|---|---|
+| 1. store_episode() LanceDB↔DuckDB desync | **Eliminated** — single Lance write, no DuckDB in write path |
+| 2. forget() partial execution | **Simplified** — TTL filter is a Lance column predicate; batch delete is one Lance operation |
+| 3. consolidate() checkpoint gap | **Deferred to Phase 3** — only relevant when DuckDB consolidation jobs exist |
+| 4. LanceGraph entity/edge atomicity | **Remains** — mitigated by M4 (entity-first ordering) |
+| 5. Entity dedup merge | **Remains** — mitigated by M4 (tombstone soft-delete) |
+| 6. embedding_cache desync | **Eliminated** — cache is embedding_cache.lance (same engine as facts.lance) |
+
+Mitigations M1 (Write-intent WAL) and M3 (startup consistency scan across Lance↔DuckDB) are deferred to Phase 3. M2 (idempotent ops) and M4 (entity-first ordering) remain P0 for Phase 1 and Phase 2 respectively.


### PR DESCRIPTION
## Summary

Formalises the Vector-First storage hierarchy based on design validation in #22 and #23.

- **`storage-architecture.md`** — rewritten with explicit three-tier model, `facts.lance` schema (incl. `ttl_expires_ms`), `embedding_cache.lance` schema, and a resolution table mapping #22 scenarios to their new status
- **`roadmap.md`** — Phase 2 is now LanceGraph-only; DuckDB moved to Phase 3; Phase 1 gains `ttl_expires_ms` and `embedding_cache.lance` milestones; design constraints (idempotent ops, entity-first ordering) documented per phase
- **`embedding-context.md`** — context assembly pipeline updated: TTL filter is a Lance predicate (Phase 1+), LanceGraph traversal is step 3 (Phase 2+), DuckDB filter is Phase 3 only

## Key architectural decisions

- `store_episode()` is a single Lance write in all phases — no two-phase commit, no DuckDB in write path
- TTL enforcement via `ttl_expires_ms` column in `facts.lance` (Lance predicate filter + versioned batch delete)
- Embedding cache moved to `embedding_cache.lance` — same engine as `facts.lance`, eliminates cross-store desync (scenario 6 of #22)
- DuckDB is an **optional analytics layer** (Phase 3), not a lifecycle manager

## Closes

Closes #22, #23

## Test plan

- [ ] Review `storage-architecture.md` three-tier diagram and schema tables
- [ ] Confirm `roadmap.md` Phase 2 contains no DuckDB milestones
- [ ] Confirm `roadmap.md` Phase 3 DuckDB scope is query-only (no write path)
- [ ] Confirm `embedding-context.md` context assembly step ordering is consistent with new hierarchy

🤖 Generated with [Claude Code](https://claude.com/claude-code)