### PR TITLE
ci: parallelize feature-set tests, skip coverage on PRs, drop redundant audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build_and_test:
-    name: Build and Test (${{ matrix.os }})
+    name: Build and Test (${{ matrix.os }}, ${{ matrix.features || 'default' }})
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -26,14 +27,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Linux: full suite including heavy C-compiled features
+          # Ubuntu: one job per feature set, all run in parallel
           - os: ubuntu-latest
-            heavy_features: true
+            features: ""
+          - os: ubuntu-latest
+            features: "store-lance"
+          - os: ubuntu-latest
+            features: "store-duck"
+          - os: ubuntu-latest
+            features: "store-lance store-duck"
           # macOS / Windows: pure Rust only -- avoids recompiling duckdb + lancedb C code
           - os: macos-latest
-            heavy_features: false
+            features: ""
           - os: windows-latest
-            heavy_features: false
+            features: ""
 
     steps:
       - name: Checkout
@@ -51,8 +58,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-cargo-${{ matrix.features }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ${{ matrix.os }}-cargo-${{ matrix.features }}-
             ${{ matrix.os }}-cargo-
 
       - name: Install protoc (Linux)
@@ -67,20 +75,16 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install protoc --yes
 
-      - name: Unit tests (default features)
-        run: cargo test
-
-      - name: Unit tests (store-lance)
-        if: ${{ matrix.heavy_features == true }}
-        run: cargo test --features store-lance
-
-      - name: Unit tests (store-duck)
-        if: ${{ matrix.heavy_features == true }}
-        run: cargo test --features store-duck
-
-      - name: Unit tests (all features)
-        if: ${{ matrix.heavy_features == true }}
-        run: cargo test --features "store-lance store-duck"
+      - name: Run tests
+        shell: bash
+        run: |
+          if [ -n "$FEATURES" ]; then
+            cargo test --features "$FEATURES"
+          else
+            cargo test
+          fi
+        env:
+          FEATURES: ${{ matrix.features }}
 
   license_check:
     name: OSS License Check
@@ -114,27 +118,8 @@ jobs:
       - name: Check licenses
         run: cargo deny check licenses
 
-  audit:
-    name: Security Audit (cargo-audit)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-
-      - name: Setup Rust
-        run: rustup show
-
-      - name: Install cargo-audit
-        run: cargo audit --version 2>/dev/null || cargo install cargo-audit --locked
-
-      - name: Run security audit
-        run: cargo audit
-
   sast:
-    name: SAST (Clippy + cargo-deny advisories)
+    name: SAST (Clippy + cargo-deny)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -176,6 +161,8 @@ jobs:
 
   coverage:
     name: Test Coverage (cargo-llvm-cov)
+    # Coverage is informational and slow (~15 min); run only on pushes to main.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -196,8 +183,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ubuntu-latest-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ubuntu-latest-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
+            ubuntu-latest-cargo-coverage-
             ubuntu-latest-cargo-
 
       - name: Install protoc
@@ -231,7 +219,7 @@ jobs:
   release_readiness:
     name: Release Readiness (dry-run)
     runs-on: ubuntu-latest
-    needs: [build_and_test, license_check, audit, sast]
+    needs: [build_and_test, license_check, sast]
     permissions:
       contents: read
 


### PR DESCRIPTION
Closes #27

## Changes

### Parallelize ubuntu feature-set tests (−~20 min on critical path)

Replaces 4 sequential `cargo test` steps in a single ubuntu job with a 6-entry matrix where all ubuntu variants run in parallel on separate runners:

| Matrix entry | What it tests |
|---|---|
| ubuntu (default) | default features |
| ubuntu (store-lance) | LanceDB store |
| ubuntu (store-duck) | DuckDB store |
| ubuntu (store-lance store-duck) | all features |
| macos (default) | pure Rust, cross-platform |
| windows (default) | pure Rust, cross-platform |

Each variant gets its own cache key (`os-cargo-features-lockfile`) to avoid thrashing.

### Skip coverage on PRs (−15 min per PR push)

`cargo llvm-cov` uses a separate instrumented build profile and cannot share artifacts with regular test builds. At ~15 min it was the second-largest job. Now gated to `main`-only pushes:

```yaml
if: github.ref == 'refs/heads/main'
```

Also gives coverage its own cache scope (`ubuntu-latest-cargo-coverage-`) so it doesn't evict test artifacts.

### Remove redundant `audit` job

`cargo-audit` and `cargo deny check advisories` (in `sast`) both scan the RustSec advisory database. Dropped the standalone `audit` job and removed it from `release_readiness` needs.

### Fix Node.js 20 deprecation warnings

Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var. All actions will be forced to Node.js 24 by default on 2026-06-02; this opts in early.

## Expected outcome

| Before | After (est.) |
|---|---|
| ~28 min (sequential ubuntu test) | ~12 min (longest parallel job: SAST or store-lance/duck) |
| Coverage runs on every PR (~15 min) | Coverage runs on main only |
| 5 jobs for advisory scanning | 1 job (cargo-deny in sast) |